### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/rails-i18n.el
+++ b/rails-i18n.el
@@ -30,6 +30,10 @@
 
 ;;; Code:
 
+(require 'savehist)
+(require 'subr-x)
+(require 'yaml)
+
 (defvar rails-i18n-use-double-quotes nil "If t, use double quotes instead single-quotes.")
 (defvar rails-i18n-project-root-function 'projectile-project-root "Function used to get project root.")
 (defvar rails-i18n-project-name-function 'projectile-project-name "Function used to get project name.")


### PR DESCRIPTION
```
In rails-i18n--set-cache:
rails-i18n.el:93:17:Warning: reference to free variable
    ‘savehist-additional-variables’
rails-i18n.el:93:17:Warning: assignment to free variable
    ‘savehist-additional-variables’
rails-i18n.el:138:15:Warning: reference to free variable
    ‘savehist-additional-variables’
rails-i18n.el:138:15:Warning: assignment to free variable
    ‘savehist-additional-variables’

In end of data:
rails-i18n.el:142:1:Warning: the following functions are not known to be defined:
    yaml-parse-string, string-join
```